### PR TITLE
Deployment instructions, and first internal jupyterhub

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,97 @@
+# Instructions for installing applications on the OME Kubernetes cluster
+
+Applications and resource on Kubernetes can be managed in two ways:
+- Individual resources/objects can be managed through Kubernetes manifests. An application will consist of several objects.
+- An application may be packaged up into something called a "Helm chart".
+
+This document contains some examples.
+Consult the README.md for each app in this repository to find out how each application should be installed or configured.
+
+
+## Prerequisites
+
+Install the clients necessary to work with the Kubernetes cluster.
+The versions of these clients are important and must be compatible with the server!
+
+If you see version errors when connecting to the cluster, or if these instructions are out of date, please ask for help.
+
+### kubectl
+Install kubectl 1.9.x: https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl
+
+If you are using homebrew the current version may be suitable (last checked 2018-03-01):
+
+    brew install kubernetes-cli
+
+### helm
+Install helm 2.7.x: https://github.com/kubernetes/helm/releases
+
+WARNING: Do not use homebrew, and do not install the latest version.
+
+Setup your client-side configuration by running:
+
+    helm init --client-only
+
+
+## Access credentials
+
+At present you must authenticate with the Kubernetes cluster using a private kubeconfig file containing a shared client certificate.
+Fetch this file and either:
+- Copy it to `~/.kube/config`; this will then be used by default
+- Export the environment variable `KUBECONFIG=path/to/kubeconfig`
+
+WARNING: This certificate currently enables full admin access.
+
+Run:
+
+    kubectl get nodes
+
+If you have set everything up correctly you should see a list of nodes in the cluster, e.g.:
+
+    NAME            STATUS    ROLES     AGE       VERSION
+    ome-lochy-m01   Ready     master    17d       v1.9.2+coreos.0
+    ome-lochy-n01   Ready     node      17d       v1.9.2+coreos.0
+    ome-lochy-n02   Ready     node      17d       v1.9.2+coreos.0
+
+Run:
+
+    helm list
+
+Check there are no errors.
+If any applications have already been installed with helm they may be listed, e.g.
+
+    NAME            REVISION        UPDATED                         STATUS         CHART                    NAMESPACE
+    nginx-ingress   1               Tue Feb 20 15:15:27 2018        DEPLOYED       nginx-ingress-0.9.3      kube-system
+
+
+## Installing applications from manifests
+
+Simply run `kubectl apply -f`, passing either a manifest file or a directory of manifests, e.g.:
+
+    kubectl apply -f idr-redmine-tracker/k8s/
+
+`kubectl apply` should be idempotent and can be safely run multiple times.
+
+The application may require additional secret manifests containing private configuration data.
+These may be stored in other repositories.
+
+
+## Installing applications with helm
+
+Helm charts need to be downloaded before they can be deployed.
+There are a set of charts that are configured by default.
+Other chart repositories can be added using
+
+    helm repo add https://EXAMPLE.ORG/chart/repo
+    helm repo update
+
+These repositories may be regularly updated, use `helm repo update` to update the list.
+
+Most charts will require configuration which can be passed as command line arguments, or in the form of one or more configuration files.
+
+For example, to install a chart run:
+
+    helm upgrade --install NAME CHART/NAME -f path/to/config.yaml  -f path/to/secret.yaml
+
+- `NAME` is your own name for the deployment, and on a shared cluster should be meaningful to others
+- `CHART/NAME` is the name of the helm chart you are installing
+If you are running version of the same applications you may wish to put it in a separate namespace (e.g. `--namespace=NAME`) to avoid conflicts.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ See https://github.com/openmicroscopy/kubernetes-platform if you want to know mo
 ## idr-redmine-tracker
 The IDR submissions ticketing system https://idr-redmine.openmicroscopy.org/.
 See https://idr.openmicroscopy.org/about/submission.html for more background on this project.
+
+
+## jupyterhub-internal
+An internal deployment of [JupyterHub](https://zero-to-jupyterhub.readthedocs.io/) for testing notebooks.
+
+
+# Documentation
+- [Deploying applications](docs/deployment.md)
+- [Developing applications](docs/development.md) (Work in progress)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,4 +1,4 @@
-# Instructions for installing applications on the OME Kubernetes cluster
+# Installing applications on the OME Kubernetes cluster
 
 Applications and resource on Kubernetes can be managed in two ways:
 - Individual resources/objects can be managed through Kubernetes manifests. An application will consist of several objects.
@@ -94,4 +94,7 @@ For example, to install a chart run:
 
 - `NAME` is your own name for the deployment, and on a shared cluster should be meaningful to others
 - `CHART/NAME` is the name of the helm chart you are installing
-If you are running version of the same applications you may wish to put it in a separate namespace (e.g. `--namespace=NAME`) to avoid conflicts.
+
+If you are running multiple versions of the same application and it requires access to the Kubernetes API (for instance, to manage additional pods) you should either:
+- Configure it so multiple versions won't conflict
+- Put it in a separate namespace (e.g. `--namespace=NAME`)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,6 @@
+# Developing applications for the Kubernetes cluster
+
+## Work in progress
+
+- Applications including non-private configuration should be included in this repository, optionally as a submodule.
+- Application should have all docker image dependencies reviewed for safety/trust/secvulns.

--- a/jupyterhub-internal/README.md
+++ b/jupyterhub-internal/README.md
@@ -1,0 +1,20 @@
+# Jupyterhub Internal
+
+Internal deployment of Jupyterhub
+Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
+
+## Installation
+
+    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+    helm repo update
+    helm upgrade --install jupyter-int --namespace=jupyter-int \
+        jupyterhub/jupyterhub --version=v0.6 \
+        -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
+
+Check if jupyterhub is ready:
+
+    kubectl --namespace=jupyter-int get pods
+
+Follow JupyterHub logs:
+
+    kubectl --namespace=jupyter-int logs -f deploy/hub

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -1,0 +1,51 @@
+hub:
+  baseUrl: /jupyterhub-internal/
+  cookieSecret: fd3cfbbfb57fdc354b273519495cc7a0197cf0a943788cfee4e3f48bcb6cf50c
+  db:
+    type: sqlite-memory
+  extraConfig: |
+    # https://github.com/jupyterhub/jupyterhub/wiki/Debug-Jupyterhub
+    c.JupyterHub.log_level = 'DEBUG'
+    c.Spawner.debug = True
+    c.KubeSpawner.singleuser_image_pull_policy = 'Always'
+
+#auth: secret
+
+proxy:
+  #secretToken: secret: openssl rand -hex 32
+  service:
+    type: ClusterIP
+
+singleuser:
+  # Must be compatible with JupyterHub 0.8
+  image:
+    name: manics/jupyter-docker
+    tag: jupyterhub-0.8
+  startTimeout: 600
+  memory:
+    limit: 1G
+    guarantee: 100M
+  storage:
+    type: NONE
+  #extraEnv: secret
+
+# Disable image pre-puller
+prePuller:
+  hook:
+    enabled: false
+  continuous:
+    enabled: false
+
+ingress:
+  enabled: true
+  hosts:
+  - ome-lochy.openmicroscopy.org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/proxy-body-size: 16m
+    ingress.kubernetes.io/proxy-read-timeout: 3600
+    ingress.kubernetes.io/proxy-send-timeout: 3600
+    #kubernetes.io/tls-acme: 'true'
+  tls:
+  - hosts:
+    - ome-lochy.openmicroscopy.org

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -1,6 +1,5 @@
 hub:
   baseUrl: /jupyterhub-internal/
-  cookieSecret: fd3cfbbfb57fdc354b273519495cc7a0197cf0a943788cfee4e3f48bcb6cf50c
   db:
     type: sqlite-memory
   extraConfig: |


### PR DESCRIPTION
This is the first iteration of an internal OME jupyterhub. Currently it has a fixed jupyter/notebook image, future work may involve adding the ability to choose from a selection.

This requires Jupyterhub 0.8 (0.7.2 is not supported).

Using the included instructions and README it should be possible for anyone with access to the kubernetes cluster credentials to deploy/redeploy jupyterhub-internal.

- https://trello.com/c/VZwfxhUE/4-notebooks-testing-infrastructure