### PR TITLE
Add jupyterhub-training

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ See https://idr.openmicroscopy.org/about/submission.html for more background on 
 An internal deployment of [JupyterHub](https://zero-to-jupyterhub.readthedocs.io/) for testing notebooks.
 
 
+## jupyterhub-training
+An internal deployment of [JupyterHub](https://zero-to-jupyterhub.readthedocs.io/) for testing training notebooks.
+This will be removed when support for multiply notebook images is added to jupyterhub-internal.
+
+
 # Documentation
 - [Deploying applications](docs/deployment.md)
 - [Developing applications](docs/development.md) (Work in progress)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An internal deployment of [JupyterHub](https://zero-to-jupyterhub.readthedocs.io
 
 ## jupyterhub-training
 An internal deployment of [JupyterHub](https://zero-to-jupyterhub.readthedocs.io/) for testing training notebooks.
-This will be removed when support for multiply notebook images is added to jupyterhub-internal.
+This will be removed when support for multiple notebook images is added to jupyterhub-internal.
 
 
 # Documentation

--- a/jupyterhub-internal/README.md
+++ b/jupyterhub-internal/README.md
@@ -1,6 +1,6 @@
-# Jupyterhub Internal
+# JupyterHub Internal
 
-Internal deployment of Jupyterhub
+Internal deployment of JupyterHub
 Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
 
 
@@ -15,7 +15,7 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
 
 ## Post-installation
 
-Check if jupyterhub is ready:
+Check if JupyterHub is ready:
 
     kubectl --namespace=jupyter-int get pods
 

--- a/jupyterhub-internal/README.md
+++ b/jupyterhub-internal/README.md
@@ -9,7 +9,7 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
     helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
     helm repo update
     helm upgrade --install jupyter-int --namespace=jupyter-int \
-        jupyterhub/jupyterhub --version=v0.7-bb12426 \
+        jupyterhub/jupyterhub --version=v0.7-d617e0a \
         -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
 
 

--- a/jupyterhub-training/README.md
+++ b/jupyterhub-training/README.md
@@ -1,0 +1,24 @@
+# Jupyterhub Internal
+
+Internal deployment of Jupyterhub for training
+Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-training/
+
+
+## Installation
+
+    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+    helm repo update
+    helm upgrade --install jupyter-train --namespace=jupyter-train \
+        jupyterhub/jupyterhub --version=v0.7-d617e0a \
+        -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
+
+
+## Post-installation
+
+Check if jupyterhub is ready:
+
+    kubectl --namespace=jupyter-train get pods
+
+Follow JupyterHub logs:
+
+    kubectl --namespace=jupyter-train logs -f deploy/hub

--- a/jupyterhub-training/README.md
+++ b/jupyterhub-training/README.md
@@ -1,6 +1,6 @@
-# Jupyterhub Internal
+# JupyterHub Training
 
-Internal deployment of Jupyterhub for training
+Internal deployment of JupyterHub for training
 Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-training/
 
 
@@ -15,7 +15,7 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-training/
 
 ## Post-installation
 
-Check if jupyterhub is ready:
+Check if JupyterHub is ready:
 
     kubectl --namespace=jupyter-train get pods
 

--- a/jupyterhub-training/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-training/zero-to-jupyterhub-config.yml
@@ -1,0 +1,48 @@
+hub:
+  #cookieSecret: secret: openssl rand -hex 32
+  baseUrl: /jupyterhub-training/
+  db:
+    type: sqlite-memory
+
+debug:
+  enabled: true
+
+#auth: secret
+
+proxy:
+  #secretToken: secret: openssl rand -hex 32
+  service:
+    type: ClusterIP
+
+singleuser:
+  image:
+    name: snoopycrimecop/training-notebooks
+    tag: master_merge_daily
+    pullPolicy: Always
+  startTimeout: 1800
+  memory:
+    limit: 1G
+    guarantee: 100M
+  storage:
+    type: NONE
+  cmd: jupyter-labhub
+  #extraEnv: secret
+
+# Disable image pre-puller
+prePuller:
+  hook:
+    enabled: false
+
+ingress:
+  enabled: true
+  hosts:
+  - ome-lochy.openmicroscopy.org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/proxy-body-size: 16m
+    ingress.kubernetes.io/proxy-read-timeout: 3600
+    ingress.kubernetes.io/proxy-send-timeout: 3600
+    #kubernetes.io/tls-acme: 'true'
+  tls:
+  - hosts:
+    - ome-lochy.openmicroscopy.org


### PR DESCRIPTION
Adds https://ome-lochy.openmicroscopy.org/jupyterhub-training/ linked to https://hub.docker.com/r/snoopycrimecop/training-notebooks/tags/. This is intended to be a temporary deployment until `jupyterhub-internal` is modified to allow a choice of multiple images.

Also bumps the zero-to-jupyterhub version.