### PR TITLE
Jupyterhub training release test (TOPIM)

### DIFF
--- a/jupyterhub-training/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-training/zero-to-jupyterhub-config.yml
@@ -22,6 +22,9 @@ singleuser:
     tag: 0.2.0
     pullPolicy: Always
   startTimeout: 1800
+  cpu:
+    limit: 2
+    guarantee: 0.1
   memory:
     limit: 2G
     guarantee: 512M

--- a/jupyterhub-training/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-training/zero-to-jupyterhub-config.yml
@@ -16,8 +16,10 @@ proxy:
 
 singleuser:
   image:
-    name: snoopycrimecop/training-notebooks
-    tag: master_merge_daily
+    #name: snoopycrimecop/training-notebooks
+    #tag: master_merge_daily
+    name: openmicroscopy/training-notebooks
+    tag: 0.2.0
     pullPolicy: Always
   startTimeout: 1800
   memory:

--- a/jupyterhub-training/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-training/zero-to-jupyterhub-config.yml
@@ -23,8 +23,8 @@ singleuser:
     pullPolicy: Always
   startTimeout: 1800
   memory:
-    limit: 1G
-    guarantee: 100M
+    limit: 2G
+    guarantee: 512M
   storage:
     type: NONE
   cmd: jupyter-labhub


### PR DESCRIPTION
Update https://ome-lochy.openmicroscopy.org/jupyterhub-training/
- Set memory limit to 2G
- Set CPU limit to 2 cpus
- Switch to tagged openmicroscopy/training-notebooks:0.2.0 image