### PR TITLE
Update jupyterhub-internal to latest helm chart, add jupyterhub-itr

### DIFF
--- a/jupyterhub-internal/README.md
+++ b/jupyterhub-internal/README.md
@@ -9,10 +9,10 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
     helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
     helm repo update
     helm upgrade --install jupyter-int --namespace=jupyter-int \
-        jupyterhub/jupyterhub --version=v0.7-e2757f0 \
+        jupyterhub/jupyterhub --version=v0.7-5bd0b65 \
         -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
 
-Note: When upgrading from the previously installed version `v0.7-d617e0a` you must add the flag `--force` due to changes in labels.
+Note: When upgrading from a previously installed version you may sometimes need to add the flag `--force` due to changes in labels.
 
 
 ## Post-installation

--- a/jupyterhub-internal/README.md
+++ b/jupyterhub-internal/README.md
@@ -9,8 +9,10 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
     helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
     helm repo update
     helm upgrade --install jupyter-int --namespace=jupyter-int \
-        jupyterhub/jupyterhub --version=v0.7-d617e0a \
+        jupyterhub/jupyterhub --version=v0.7-e2757f0 \
         -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
+
+Note: When upgrading from the previously installed version `v0.7-d617e0a` you must add the flag `--force` due to changes in labels.
 
 
 ## Post-installation

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -89,7 +89,6 @@ ingress:
     ingress.kubernetes.io/proxy-body-size: 16m
     ingress.kubernetes.io/proxy-read-timeout: 3600
     ingress.kubernetes.io/proxy-send-timeout: 3600
-    #kubernetes.io/tls-acme: 'true'
   tls:
   - hosts:
     - ome-lochy.openmicroscopy.org

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -71,7 +71,9 @@ singleuser:
   storage:
     type: NONE
   cmd: jupyter-labhub
-  #extraEnv: secret
+  extraEnv:
+    IDR_HOST: idr.openmicroscopy.org
+    IDR_USER: public
 
 # Disable image pre-puller
 prePuller:

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -62,9 +62,12 @@ singleuser:
     tag: master_merge_trigger
     pullPolicy: Always
   startTimeout: 1800
+  cpu:
+    limit: 2
+    guarantee: 0.1
   memory:
-    limit: 1G
-    guarantee: 100M
+    limit: 2G
+    guarantee: 512M
   storage:
     type: NONE
   cmd: jupyter-labhub

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -41,12 +41,6 @@ hub:
           'singleuser_image_spec':
             'openmicroscopy/training-notebooks:latest',
         }
-      }, {
-        'display_name': 'manics/idr-notebooks:devel',
-        'kubespawner_override': {
-          'singleuser_image_spec':
-            'manics/idr-notebooks:devel',
-        }
       }
     ]
 

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -3,6 +3,48 @@ hub:
   baseUrl: /jupyterhub-internal/
   db:
     type: sqlite-memory
+  extraConfig: |
+    c.KubeSpawner.profile_list = [
+      {
+        'display_name': 'snoopycrimecop/jupyter-docker:master_merge_daily',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'snoopycrimecop/jupyter-docker:master_merge_daily',
+        }
+      }, {
+        'display_name': 'snoopycrimecop/idr-notebooks:master_merge_daily',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'snoopycrimecop/idr-notebooks:master_merge_daily',
+        }
+      }, {
+        'display_name': 'imagedata/idr-notebooks:latest',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'imagedata/idr-notebooks:latest',
+        }
+      }, {
+        'display_name': 'snoopycrimecop/training-notebooks:master_merge_daily',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'snoopycrimecop/training-notebooks:master_merge_daily',
+        }
+      }, {
+        'display_name': 'openmicroscopy/training-notebooks:latest',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'openmicroscopy/training-notebooks:latest',
+        }
+      }, {
+        'display_name': 'manics/idr-notebooks:devel',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'manics/idr-notebooks:devel',
+        }
+      }
+    ]
+
+
 
 debug:
   enabled: true

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -18,6 +18,12 @@ hub:
             'snoopycrimecop/idr-notebooks:master_merge_daily',
         }
       }, {
+        'display_name': 'snoopycrimecop/idr-notebooks:itr_merge_daily',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'snoopycrimecop/idr-notebooks:itr_merge_daily',
+        }
+      }, {
         'display_name': 'imagedata/idr-notebooks:latest',
         'kubespawner_override': {
           'singleuser_image_spec':

--- a/jupyterhub-itr/README.md
+++ b/jupyterhub-itr/README.md
@@ -1,0 +1,26 @@
+# JupyterHub ITR
+
+Internal deployment of JupyterHub for testing the ITR
+Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-itr/
+
+
+## Installation
+
+    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+    helm repo update
+    helm upgrade --install jupyter-int --namespace=jupyter-int \
+        jupyterhub/jupyterhub --version=v0.7-d4d1fb7 \
+        -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
+
+Note: When upgrading from a previously installed version you may sometimes need to add the flag `--force` due to changes in labels.
+
+
+## Post-installation
+
+Check if JupyterHub is ready:
+
+    kubectl --namespace=jupyter-itr get pods
+
+Follow JupyterHub logs:
+
+    kubectl --namespace=jupyter-itr logs -f deploy/hub

--- a/jupyterhub-itr/README.md
+++ b/jupyterhub-itr/README.md
@@ -9,7 +9,7 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-itr/
     helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
     helm repo update
     helm upgrade --install jupyter-int --namespace=jupyter-int \
-        jupyterhub/jupyterhub --version=v0.7-d4d1fb7 \
+        jupyterhub/jupyterhub --version=v0.7-15e87d6 \
         -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
 
 Note: When upgrading from a previously installed version you may sometimes need to add the flag `--force` due to changes in labels.

--- a/jupyterhub-itr/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-itr/zero-to-jupyterhub-config.yml
@@ -17,8 +17,10 @@ proxy:
 
 singleuser:
   image:
-    name: snoopycrimecop/idr-notebooks
-    tag: itr_merge_daily
+    #name: snoopycrimecop/idr-notebooks
+    #tag: itr_merge_daily
+    name: manics/idr-notebooks
+    tag: devel
     pullPolicy: Always
   startTimeout: 1800
   cpu:
@@ -29,7 +31,7 @@ singleuser:
     guarantee: 512M
   storage:
     type: NONE
-  #cmd: jupyter-labhub
+  cmd: jupyter-labhub
   extraEnv:
     IDR_HOST: idr.openmicroscopy.org
     IDR_USER: public

--- a/jupyterhub-itr/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-itr/zero-to-jupyterhub-config.yml
@@ -29,7 +29,7 @@ singleuser:
     limit: 2
     guarantee: 0.1
   memory:
-    limit: 8G
+    limit: 6.5G
     guarantee: 512M
   storage:
     type: NONE

--- a/jupyterhub-itr/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-itr/zero-to-jupyterhub-config.yml
@@ -1,0 +1,54 @@
+hub:
+  #cookieSecret: secret: openssl rand -hex 32
+  baseUrl: /jupyterhub-itr/
+  db:
+    type: sqlite-memory
+
+debug:
+  enabled: true
+
+auth:
+  type: tmp
+
+proxy:
+  #secretToken: secret: openssl rand -hex 32
+  service:
+    type: ClusterIP
+
+singleuser:
+  image:
+    name: snoopycrimecop/idr-notebooks
+    tag: itr_merge_daily
+    pullPolicy: Always
+  startTimeout: 1800
+  cpu:
+    limit: 2
+    guarantee: 0.1
+  memory:
+    limit: 2G
+    guarantee: 512M
+  storage:
+    type: NONE
+  #cmd: jupyter-labhub
+  extraEnv:
+    IDR_HOST: idr.openmicroscopy.org
+    IDR_USER: public
+
+# Disable image pre-puller
+prePuller:
+  hook:
+    enabled: false
+
+ingress:
+  enabled: true
+  hosts:
+  - ome-lochy.openmicroscopy.org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/proxy-body-size: 16m
+    ingress.kubernetes.io/proxy-read-timeout: 3600
+    ingress.kubernetes.io/proxy-send-timeout: 3600
+    #kubernetes.io/tls-acme: 'true'
+  tls:
+  - hosts:
+    - ome-lochy.openmicroscopy.org

--- a/jupyterhub-itr/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-itr/zero-to-jupyterhub-config.yml
@@ -17,10 +17,8 @@ proxy:
 
 singleuser:
   image:
-    #name: snoopycrimecop/idr-notebooks
-    #tag: itr_merge_daily
-    name: manics/idr-notebooks
-    tag: devel
+    name: snoopycrimecop/idr-notebooks
+    tag: itr_merge_daily
     pullPolicy: Always
   startTimeout: 1800
   cpu:
@@ -31,7 +29,7 @@ singleuser:
     guarantee: 512M
   storage:
     type: NONE
-  cmd: jupyter-labhub
+  #cmd: jupyter-labhub
   extraEnv:
     IDR_HOST: idr.openmicroscopy.org
     IDR_USER: public

--- a/jupyterhub-itr/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-itr/zero-to-jupyterhub-config.yml
@@ -3,6 +3,10 @@ hub:
   baseUrl: /jupyterhub-itr/
   db:
     type: sqlite-memory
+  # Storing the db in memory means it's lost on restart
+  # This may help to avoid dangling servers
+  extraConfig: |
+    c.JupyterHub.cleanup_servers = True
 
 debug:
   enabled: true
@@ -25,7 +29,7 @@ singleuser:
     limit: 2
     guarantee: 0.1
   memory:
-    limit: 2G
+    limit: 4G
     guarantee: 512M
   storage:
     type: NONE

--- a/jupyterhub-itr/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-itr/zero-to-jupyterhub-config.yml
@@ -29,7 +29,7 @@ singleuser:
     limit: 2
     guarantee: 0.1
   memory:
-    limit: 4G
+    limit: 8G
     guarantee: 512M
   storage:
     type: NONE

--- a/jupyterhub-itr/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-itr/zero-to-jupyterhub-config.yml
@@ -52,7 +52,6 @@ ingress:
     ingress.kubernetes.io/proxy-body-size: 16m
     ingress.kubernetes.io/proxy-read-timeout: 3600
     ingress.kubernetes.io/proxy-send-timeout: 3600
-    #kubernetes.io/tls-acme: 'true'
   tls:
   - hosts:
     - ome-lochy.openmicroscopy.org


### PR DESCRIPTION
~This includes an upgrade to JupyterHub 0.9 which is backward compatible with 0.8 images, and is intended to help us test whether our notebook images can be easily updated to JupyterHub 0.9.~

This PR takes advantage of new features to provide a dropdown of images, allowing this jupyterhub instance to support multiple notebook images. This means https://ome-lochy.openmicroscopy.org/jupyterhub-training could be removed in future.

![screen shot 2018-06-29 at 17 06 39-fullpage](https://user-images.githubusercontent.com/1644105/42102778-eabffdf6-7bbe-11e8-8014-9c23f7a9d17a.png)

## Testing notes

https://ome-lochy.openmicroscopy.org/jupyterhub-internal

Also adds https://ome-lochy.openmicroscopy.org/jupyterhub-itr