### PR TITLE
Set idr-redmine nginx ingress proxy-body-size to 32m

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -8,7 +8,7 @@ releases:
     group: ingress
     name: nginx-ingress
   chart: stable/nginx-ingress
-  version: 0.20.3
+  version: 0.28.2
   values:
   - nginx-ingress/nginx-ingress.yml
 

--- a/idr-redmine/idr-redmine-tracker.yml
+++ b/idr-redmine/idr-redmine-tracker.yml
@@ -20,3 +20,5 @@ gmail:
 
 ingress:
   host: idr-redmine.openmicroscopy.org
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 16m

--- a/idr-redmine/idr-redmine-tracker.yml
+++ b/idr-redmine/idr-redmine-tracker.yml
@@ -21,4 +21,4 @@ gmail:
 ingress:
   host: idr-redmine.openmicroscopy.org
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: 16m
+    nginx.ingress.kubernetes.io/proxy-body-size: 32m


### PR DESCRIPTION
This allows uploads (such as file attachments) of up to ~16~32 MB. Note Redmine has a separate configurable limit which might need to be bumped.
- [ ] --depends-on https://github.com/openmicroscopy/idr-redmine-tracker/pull/5