### PR TITLE
Add jupyterhub-* to helmfile

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,4 +1,11 @@
+repositories:
+- name: jupyterhub
+  url: https://jupyterhub.github.io/helm-chart/
+
+
 releases:
+
+## System
 
 
 - name: nginx-ingress
@@ -12,6 +19,8 @@ releases:
   values:
   - nginx-ingress/nginx-ingress.yml
 
+
+## Monitoring
 
 - name: grafana-playground-storage
   namespace: monitoring
@@ -142,6 +151,8 @@ releases:
   - ../config/prometheus-global/prometheus.yml
 
 
+## Redmine
+
 - name: idr-redmine-storage
   namespace: idr-redmine
   labels:
@@ -164,3 +175,39 @@ releases:
   # NOTE: you must create secret manually with the current config:
   # pass show x/idr-redmine/secret-config.yaml > idr-redmine/secret-config.yaml
   # kubectl apply -f idr-redmine/secret-config.yaml
+
+
+## JupyterHub
+
+- name: jupyter-int
+  namespace: jupyter-int
+  labels:
+    app: jupyterhub
+    group: jupyterhub
+  chart: jupyterhub/jupyterhub
+  version: v0.7-5bd0b65
+  values:
+  - jupyterhub-internal/zero-to-jupyterhub-config.yml
+  - ../config/jupyterhub-internal/zero-to-jupyterhub-secret.yml
+
+- name: jupyter-itr
+  namespace: jupyter-itr
+  labels:
+    app: jupyterhub
+    group: jupyterhub
+  chart: jupyterhub/jupyterhub
+  version: v0.7-15e87d6
+  values:
+  - jupyterhub-itr/zero-to-jupyterhub-config.yml
+  - ../config/jupyterhub-itr/zero-to-jupyterhub-secret.yml
+
+- name: jupyter-train
+  namespace: jupyter-train
+  labels:
+    app: jupyterhub
+    group: jupyterhub
+  chart: jupyterhub/jupyterhub
+  version: v0.7-d617e0a
+  values:
+  - jupyterhub-training/zero-to-jupyterhub-config.yml
+  - ../config/jupyterhub-training/zero-to-jupyterhub-secret.yml

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -13,7 +13,6 @@ releases:
   labels:
     app: nginx-ingress
     group: ingress
-    name: nginx-ingress
   chart: stable/nginx-ingress
   version: 0.28.2
   values:
@@ -27,7 +26,6 @@ releases:
   labels:
     app: storage
     group: monitoring
-    name: grafana-playground-storage
   chart: ./charts/nfs-volume
   values:
   - grafana-playground/nfs-volume.yml
@@ -37,7 +35,6 @@ releases:
   labels:
     app: grafana
     group: monitoring
-    name: grafana-playground
   chart: stable/grafana
   # Latest version has a bug https://github.com/kubernetes/charts/pull/6196
   version: 1.10.2
@@ -51,7 +48,6 @@ releases:
   labels:
     app: storage
     group: monitoring
-    name: grafana-global-storage
   chart: ./charts/nfs-volume
   values:
   - grafana-global/nfs-volume.yml
@@ -61,7 +57,6 @@ releases:
   labels:
     app: grafana
     group: monitoring
-    name: grafana-global
   chart: stable/grafana
   # Latest version has a bug https://github.com/kubernetes/charts/pull/6196
   version: 1.10.2
@@ -75,7 +70,6 @@ releases:
   labels:
     app: oauth2-proxy
     group: monitoring
-    name: monitoring-oauth2
   # The official stable/oauth2-proxy chart doesn't work
   chart: ./charts/oauth2-proxy
   values:
@@ -88,7 +82,6 @@ releases:
   labels:
     app: storage
     group: monitoring
-    name: prometheus-k8s-storage
   chart: ./charts/nfs-volume
   values:
   - prometheus-k8s/nfs-volume.yml
@@ -98,7 +91,6 @@ releases:
   labels:
     app: prometheus
     group: monitoring
-    name: prometheus-k8s
   chart: stable/prometheus
   version: 6.7.4
   values:
@@ -110,7 +102,6 @@ releases:
   labels:
     app: storage
     group: monitoring
-    name: prometheus-ome-storage
   chart: ./charts/nfs-volume
   values:
   - prometheus-ome/nfs-volume.yml
@@ -120,7 +111,6 @@ releases:
   labels:
     app: prometheus
     group: monitoring
-    name: prometheus-ome
   chart: stable/prometheus
   version: 6.7.4
   values:
@@ -133,7 +123,6 @@ releases:
   labels:
     app: storage
     group: monitoring
-    name: prometheus-global-storage
   chart: ./charts/nfs-volume
   values:
   - prometheus-global/nfs-volume.yml
@@ -143,7 +132,6 @@ releases:
   labels:
     app: prometheus
     group: monitoring
-    name: prometheus-global
   chart: stable/prometheus
   version: 6.7.4
   values:
@@ -158,7 +146,6 @@ releases:
   labels:
     app: storage
     group: redmine
-    name: idr-redmine-storage
   chart: ./charts/nfs-volume
   values:
   - idr-redmine/nfs-volume.yml
@@ -168,7 +155,6 @@ releases:
   labels:
     app: redmine
     group: redmine
-    name: idr-redmine
   chart: ./idr-redmine-tracker/chart
   values:
   - idr-redmine/idr-redmine-tracker.yml

--- a/jupyterhub-internal/README.md
+++ b/jupyterhub-internal/README.md
@@ -6,11 +6,7 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
 
 ## Installation
 
-    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
-    helm repo update
-    helm upgrade --install jupyter-int --namespace=jupyter-int \
-        jupyterhub/jupyterhub --version=v0.7-5bd0b65 \
-        -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
+See [helmfile.yaml](../helmfile.yaml)
 
 Note: When upgrading from a previously installed version you may sometimes need to add the flag `--force` due to changes in labels.
 

--- a/jupyterhub-itr/README.md
+++ b/jupyterhub-itr/README.md
@@ -6,11 +6,7 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-itr/
 
 ## Installation
 
-    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
-    helm repo update
-    helm upgrade --install jupyter-int --namespace=jupyter-int \
-        jupyterhub/jupyterhub --version=v0.7-15e87d6 \
-        -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
+See [helmfile.yaml](../helmfile.yaml)
 
 Note: When upgrading from a previously installed version you may sometimes need to add the flag `--force` due to changes in labels.
 

--- a/jupyterhub-training/README.md
+++ b/jupyterhub-training/README.md
@@ -6,11 +6,9 @@ Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-training/
 
 ## Installation
 
-    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
-    helm repo update
-    helm upgrade --install jupyter-train --namespace=jupyter-train \
-        jupyterhub/jupyterhub --version=v0.7-d617e0a \
-        -f zero-to-jupyterhub-config.yml -f path/to/zero-to-jupyterhub-secret.yml
+See [helmfile.yaml](../helmfile.yaml)
+
+Note: When upgrading from a previously installed version you may sometimes need to add the flag `--force` due to changes in labels.
 
 
 ## Post-installation


### PR DESCRIPTION
This converts the remaining README deployment instructions into the appropriate helmfile definitions.

Also removes the helmfile `name:` label since it's implicitly defined.