### PR TITLE
JupyterHub internal shared storage

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -165,6 +165,15 @@ releases:
 
 ## JupyterHub
 
+- name: jupyterhub-internal-storage
+  namespace: jupyter-int
+  labels:
+    app: storage
+    group: jupyterhub
+  chart: ./charts/nfs-volume
+  values:
+  - jupyterhub-internal/nfs-volume.yml
+
 - name: jupyter-int
   namespace: jupyter-int
   labels:

--- a/jupyterhub-internal/README.md
+++ b/jupyterhub-internal/README.md
@@ -4,6 +4,13 @@ Internal deployment of JupyterHub
 Application URL: https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
 
 
+## Pre-installation
+
+Create NFS directory `/uod/idr/k8s-volumes/jupyterhub-internal`.
+Create NFS sub-directory `/uod/idr/k8s-volumes/jupyterhub-internal/shared`.
+Change the user id of the sub-directory to `1000`.
+
+
 ## Installation
 
 See [helmfile.yaml](../helmfile.yaml)

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -70,6 +70,14 @@ singleuser:
     guarantee: 512M
   storage:
     type: NONE
+    extraVolumes:
+    - name: jupyterhub-sharedscratch-rw
+      persistentVolumeClaim:
+        claimName: jupyterhub-internal-storage-nfs-volume
+    extraVolumeMounts:
+    - name: jupyterhub-sharedscratch-rw
+      mountPath: /home/jovyan/shared
+      subPath: shared
   cmd: jupyter-labhub
   extraEnv:
     IDR_HOST: idr.openmicroscopy.org

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -106,9 +106,9 @@ ingress:
   - ome-lochy.openmicroscopy.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    ingress.kubernetes.io/proxy-body-size: 16m
-    ingress.kubernetes.io/proxy-read-timeout: 3600
-    ingress.kubernetes.io/proxy-send-timeout: 3600
+    nginx.ingress.kubernetes.io/proxy-body-size: 16m
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
+    nginx.ingress.kubernetes.io/proxy-send-timeout: 3600
   tls:
   - hosts:
     - ome-lochy.openmicroscopy.org

--- a/jupyterhub-internal/zero-to-jupyterhub-config.yml
+++ b/jupyterhub-internal/zero-to-jupyterhub-config.yml
@@ -30,6 +30,12 @@ hub:
             'imagedata/idr-notebooks:latest',
         }
       }, {
+        'display_name': 'imagedata/idr-notebooks:VAE-0.5.2',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'imagedata/idr-notebooks:VAE-0.5.2',
+        }
+      }, {
         'display_name': 'snoopycrimecop/training-notebooks:master_merge_daily',
         'kubespawner_override': {
           'singleuser_image_spec':
@@ -40,6 +46,12 @@ hub:
         'kubespawner_override': {
           'singleuser_image_spec':
             'openmicroscopy/training-notebooks:latest',
+        }
+      }, {
+        'display_name': 'openmicroscopy/training-notebooks:0.3.0',
+        'kubespawner_override': {
+          'singleuser_image_spec':
+            'openmicroscopy/training-notebooks:0.3.0',
         }
       }
     ]


### PR DESCRIPTION
This adds a shared persistent directory to jupyterhub-internal, and fixes the nginx ingress config to allow up to 16MB uploads.

## Testing

Log on to https://ome-lochy.openmicroscopy.org/jupyterhub-internal/
Change to the home directory; you should see a directory called `shared`.
**WARNING**: At present everyone runs as the same jupyter Docker UID, which means anyone can modify anyone elses files in `shared`. This may be improved in future.

You can also test that uploads <16MB are allowed (previously <1MB due to a misconfiguration)