### PR TITLE
OMERO-grafana datasource

### DIFF
--- a/charts/generic-webapp/.helmignore
+++ b/charts/generic-webapp/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/generic-webapp/Chart.yaml
+++ b/charts/generic-webapp/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Generic webapp deployment
+name: generic-webapp
+version: 0.1.0

--- a/charts/generic-webapp/README.md
+++ b/charts/generic-webapp/README.md
@@ -1,0 +1,10 @@
+# Generic webapp
+
+A generic helm chart for deploying self-contained single-container single-pod stateless web services.
+
+See [`values.yaml`](values.yaml) for all parameters.
+
+For a typical web-app the following may need to be configured:
+- `image.repository`: Docker image for the web-app (required)
+- `image.tag`: Image tag, default `latest` but you should use a released tag in production
+- `internalPort`: Internal container port that the web-app is running on, default `80`

--- a/charts/generic-webapp/templates/NOTES.txt
+++ b/charts/generic-webapp/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "generic-webapp.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "generic-webapp.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "generic-webapp.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "generic-webapp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/generic-webapp/templates/_helpers.tpl
+++ b/charts/generic-webapp/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "generic-webapp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "generic-webapp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "generic-webapp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/generic-webapp/templates/deployment.yaml
+++ b/charts/generic-webapp/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "generic-webapp.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "generic-webapp.name" . }}
+    helm.sh/chart: {{ include "generic-webapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "generic-webapp.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "generic-webapp.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ required "image.repository required" .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command:
+            {{- range $value := .Values.command }}
+            - {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.args }}
+          args:
+            {{- range $value := .Values.args }}
+            - {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.internalPort }}
+              protocol: TCP
+        {{- if .Values.probe.liveness.path }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probe.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probe.liveness.initialDelay }}
+        {{- end }}
+        {{- if .Values.probe.readiness.path }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probe.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probe.readiness.initialDelay }}
+        {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/generic-webapp/templates/ingress.yaml
+++ b/charts/generic-webapp/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "generic-webapp.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "generic-webapp.name" . }}
+    helm.sh/chart: {{ include "generic-webapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/generic-webapp/templates/service.yaml
+++ b/charts/generic-webapp/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "generic-webapp.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "generic-webapp.name" . }}
+    helm.sh/chart: {{ include "generic-webapp.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "generic-webapp.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/generic-webapp/values.yaml
+++ b/charts/generic-webapp/values.yaml
@@ -1,0 +1,67 @@
+# Default values for generic-webapp.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository:
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Container port
+internalPort: 80
+# Override the default container command (array, equivalent to Docker entrypoint)
+command: []
+# Arguments passed to command (array, equivalent to Docker cmd)
+args: []
+# A dictionary of environment variables
+env: {}
+
+# Liveness and readiness paths, set probe.{liveness,readiness}.path
+# to empty to disable
+probe:
+  liveness:
+    path: /
+    initialDelay: 5
+  readiness:
+    path: /
+    initialDelay: 5
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - localhost
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/grafana-global/grafana.yml
+++ b/grafana-global/grafana.yml
@@ -28,3 +28,6 @@ env:
   GF_SERVER_DOMAIN: monitoring.openmicroscopy.org
   GF_SERVER_ROOT_URL: "https://%(domain)s/grafana-global/"
   GF_USERS_AUTO_ASSIGN_ORG_ROLE: Viewer
+
+plugins:
+- grafana-simple-json-datasource

--- a/grafana-playground/grafana.yml
+++ b/grafana-playground/grafana.yml
@@ -28,3 +28,6 @@ env:
   GF_SERVER_DOMAIN: monitoring.openmicroscopy.org
   GF_SERVER_ROOT_URL: "https://%(domain)s/grafana-playground/"
   GF_USERS_AUTO_ASSIGN_ORG_ROLE: Admin
+
+plugins:
+- grafana-simple-json-datasource

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -139,6 +139,16 @@ releases:
   - ../config/prometheus-global/prometheus.yml
 
 
+- name: omero-grafana-ds
+  namespace: monitoring
+  labels:
+    app: omero-grafana-json-datasource
+    group: monitoring
+  chart: ./charts/generic-webapp
+  values:
+  - omero-grafana-ds/generic-webapp.yml
+
+
 ## Redmine
 
 - name: idr-redmine-storage

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -36,8 +36,7 @@ releases:
     app: grafana
     group: monitoring
   chart: stable/grafana
-  # Latest version has a bug https://github.com/kubernetes/charts/pull/6196
-  version: 1.10.2
+  version: 1.17.4
   values:
   - grafana-playground/grafana.yml
   - ../config/grafana-playground/grafana-secret.yml
@@ -58,8 +57,7 @@ releases:
     app: grafana
     group: monitoring
   chart: stable/grafana
-  # Latest version has a bug https://github.com/kubernetes/charts/pull/6196
-  version: 1.10.2
+  version: 1.17.4
   values:
   - grafana-global/grafana.yml
   - ../config/grafana-global/grafana-secret.yml

--- a/omero-grafana-ds/README.md
+++ b/omero-grafana-ds/README.md
@@ -1,0 +1,12 @@
+# OMERO Grafana JSON Datasource
+
+OMERO Grafana JSON Datasource utility to allow OMERO to be queried by Grafana using the grafana-simple-json-datasource plugin.
+
+Application URL: https://ome-lochy.openmicroscopy.org/omero-grafana-ds/
+
+Example Grafana SimpleJson datasource URL https://ome-lochy.openmicroscopy.org/omero-grafana-ds/example-omero.openmicroscopy.org
+
+
+## Installation
+
+See [helmfile.yaml](../helmfile.yaml)

--- a/omero-grafana-ds/generic-webapp.yml
+++ b/omero-grafana-ds/generic-webapp.yml
@@ -1,0 +1,32 @@
+image:
+  repository: registry.gitlab.com/openmicroscopy/incubator/omero-grafana-json-datasource
+  tag: 0.1.1
+
+internalPort: 5000
+args:
+  - --workers
+  - 2
+  - --timeout
+  - 60
+
+probe:
+  liveness:
+    # Sometimes seems to be a bit slow starting up
+    initialDelay: 60
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+  path: /omero-grafana-ds
+  hosts:
+  - ome-lochy.openmicroscopy.org
+  tls:
+  - hosts:
+    - ome-lochy.openmicroscopy.org
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 1Gi


### PR DESCRIPTION
- Adds a generic webapp helm chart that can be used for deploying simple standalone web apps without having to write a whole new Helm Chart.
- Deploys a stateless proxy-app https://gitlab.com/openmicroscopy/incubator/omero-grafana-json-datasource (gitlab repo docker registry)
- Updates Grafana to the latest helm chart
- Installs the grafana-simple-json-datasource plugin to support connection to omero-grafana-json-datasource

Dashboards and Datasources will be configured through the Grafana UI, no further deployment changes are needed unless we want to pull out additional information from OMERO.

- https://trello.com/c/Zs77bh3X/43-omero-server-profiling-scripts