### PR TITLE
Enable minio http tracing

### DIFF
--- a/minio/minio.yml
+++ b/minio/minio.yml
@@ -23,3 +23,6 @@ ingress:
   - hosts:
     - minio.openmicroscopy.org
   path: /
+
+debug:
+  http: /export/minio-http-trace.log


### PR DESCRIPTION
This is required to find out why some S3 requests are failing. See https://github.com/openmicroscopy/minio-helm-chart/pull/2

This will log to `/uod/idr/objectstore/minio/minio-http-trace.log`

- [x] --depends-on https://github.com/openmicroscopy/minio-helm-chart/pull/2