### PR TITLE
Update minio (minio-dev) to latest Helm chart

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,7 +1,8 @@
 repositories:
 - name: jupyterhub
   url: https://jupyterhub.github.io/helm-chart/
-
+- name: minio
+  url: https://helm.min.io/
 
 releases:
 
@@ -212,7 +213,8 @@ releases:
   labels:
     app: minio
     group: objectstore
-  chart: ./charts/minio
+  chart: minio/minio
+  version: 8.0.0
   values:
   - minio/minio.yml
   - ../config/minio/minio.yml

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -219,12 +219,13 @@ releases:
   - minio/minio.yml
   - ../config/minio/minio.yml
 
-- name: minio-slow
-  namespace: minio
-  labels:
-    app: minio
-    group: objectstore
-  chart: ./charts/minio
-  values:
-  - minio-slow/minio.yml
-  - ../config/minio-slow/minio.yml
+# ./charts/minio/ needs to be updated to match the above version
+# - name: minio-slow
+#   namespace: minio
+#   labels:
+#     app: minio
+#     group: objectstore
+#   chart: ./charts/minio
+#   values:
+#   - minio-slow/minio.yml
+#   - ../config/minio-slow/minio.yml

--- a/minio/minio.yml
+++ b/minio/minio.yml
@@ -6,6 +6,10 @@ persistence:
   existingClaim: minio-storage-nfs-volume
   accessMode: ReadWriteMany
 
+securityContext:
+  # Run as root to have write access to the existing data
+  enabled: false
+
 nasgateway:
   enabled: true
   replicas: 1
@@ -27,4 +31,3 @@ ingress:
   - hosts:
     - minio.openmicroscopy.org
     - minio-dev.openmicroscopy.org
-  path: /


### PR DESCRIPTION
minio-slow is not updated as it uses a [fork of the main chart](https://github.com/ome/minio-helm-chart/tree/14d25122613ed8d6730192788b14901883319f03) to enable network throttling. As discussed we can return to this later if necessary. For now I've deleted the deployment but kept the config files.

It may be possible to keep it running, but since minio writes to some metadata files we'd have to check whether the versions are compatible.